### PR TITLE
[#5] Flip H, Flit V 기능

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,3 +1,4 @@
+import * as cornerstone from 'cornerstone-core';
 import * as cornerstoneTools from 'cornerstone-tools';
 
 const Header = ({ currentEl }: { currentEl: HTMLDivElement | undefined }) => {
@@ -5,6 +6,36 @@ const Header = ({ currentEl }: { currentEl: HTMLDivElement | undefined }) => {
     cornerstoneTools.setToolActiveForElement(currentEl, 'ZoomMouseWheel', {
       mouseButtonMask: 1
     });
+  };
+
+  const flipHHandler = () => {
+    cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
+      mouseButtonMask: 1
+    });
+
+    if (currentEl) {
+      const viewport = cornerstone.getViewport(currentEl);
+
+      if (viewport) {
+        viewport.hflip = !viewport.hflip;
+        cornerstone.setViewport(currentEl, viewport);
+      }
+    }
+  };
+
+  const flipVHandler = () => {
+    cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
+      mouseButtonMask: 1
+    });
+
+    if (currentEl) {
+      const viewport = cornerstone.getViewport(currentEl);
+
+      if (viewport) {
+        viewport.vflip = !viewport.vflip;
+        cornerstone.setViewport(currentEl, viewport);
+      }
+    }
   };
 
   return (
@@ -17,8 +48,12 @@ const Header = ({ currentEl }: { currentEl: HTMLDivElement | undefined }) => {
           <button className="feat-btn" onClick={zoomHandler}>
             Zoom
           </button>
-          <button className="feat-btn">Flip H</button>
-          <button className="feat-btn">Filp V</button>
+          <button className="feat-btn" onClick={flipHHandler}>
+            Flip H
+          </button>
+          <button className="feat-btn" onClick={flipVHandler}>
+            Filp V
+          </button>
           <button className="feat-btn">Rotate Delta 30</button>
           <button className="feat-btn">Invert</button>
           <button className="feat-btn">Apply Colormap</button>


### PR DESCRIPTION
close #5 

## Description

<!-- 작업 내용을 적어주세요. -->

### 1. cornerstoneTools을 활용한 Flip H, Flit V 기능 구현

- 각 버튼을 눌러 기능 전환 시, zoom 기능은 setToolEnabledForElement을 통해 동작하지 않도록 하였습니다.
- 현재 선택된 currentEl를 사용하여 viewport를 불러오고, viewport.hflip 와 viewport.vflip를 사용하여 각 기능을 구현하였습니다.

## 스크린샷 (Optional)

https://github.com/JitHoon/dicom-viewer/assets/101972330/190f17a0-50cc-45b3-afb8-e8a5d689ede2
