### PR TITLE
[#11] Previous & Next Image 기능

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,8 @@ function App() {
   const dicomARef = createRef<HTMLDivElement>();
   const dicomBRef = createRef<HTMLDivElement>();
   const [currentEl, setCurrentEl] = useState<HTMLDivElement>();
-  const [currentImageA, _setCurrentImageA] = useState<number>(0);
-  const [currentImageB, _setCurrentImageB] = useState<number>(1);
+  const [currentImageA, setCurrentImageA] = useState<number>(0);
+  const [currentImageB, setCurrentImageB] = useState<number>(1);
 
   const imageId_1 =
     'https://rawgit.com/cornerstonejs/cornerstoneWebImageLoader/master/examples/Renal_Cell_Carcinoma.jpg';
@@ -81,9 +81,32 @@ function App() {
       } else return pre;
     });
 
+  // change imageA
+  useEffect(() => {
+    if (currentEl) {
+      cornerstone.loadAndCacheImage(imageIds[currentImageA]).then(image => {
+        cornerstone.displayImage(currentEl, image);
+      });
+    }
+  }, [currentImageA]);
+
+  // change imageB
+  useEffect(() => {
+    if (currentEl) {
+      cornerstone.loadAndCacheImage(imageIds[currentImageB]).then(image => {
+        cornerstone.displayImage(currentEl, image);
+      });
+    }
+  }, [currentImageB]);
+
   return (
     <>
-      <Header currentEl={currentEl} />
+      <Header
+        currentEl={currentEl}
+        setCurrentImageA={setCurrentImageA}
+        setCurrentImageB={setCurrentImageB}
+        imageIds={imageIds}
+      />
       <main className="box-border flex h-[85vh] w-full items-center justify-center">
         <div
           id="A"

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,17 @@
 import * as cornerstone from 'cornerstone-core';
 import * as cornerstoneTools from 'cornerstone-tools';
 
-const Header = ({ currentEl }: { currentEl: HTMLDivElement | undefined }) => {
+const Header = ({
+  currentEl,
+  setCurrentImageA,
+  setCurrentImageB,
+  imageIds
+}: {
+  currentEl: HTMLDivElement | undefined;
+  setCurrentImageA: React.Dispatch<React.SetStateAction<number>>;
+  setCurrentImageB: React.Dispatch<React.SetStateAction<number>>;
+  imageIds: string[];
+}) => {
   const zoomHandler = () => {
     cornerstoneTools.setToolActiveForElement(currentEl, 'ZoomMouseWheel', {
       mouseButtonMask: 1
@@ -66,6 +76,22 @@ const Header = ({ currentEl }: { currentEl: HTMLDivElement | undefined }) => {
     }
   };
 
+  const previousHeandler = () => {
+    if (currentEl?.id === 'A') {
+      setCurrentImageA(pre => Math.abs(pre - 1) % imageIds.length);
+    } else if (currentEl?.id === 'B') {
+      setCurrentImageB(pre => Math.abs(pre - 1) % imageIds.length);
+    }
+  };
+
+  const nextHandler = () => {
+    if (currentEl?.id === 'A') {
+      setCurrentImageA(pre => (pre + 1) % imageIds.length);
+    } else if (currentEl?.id === 'B') {
+      setCurrentImageB(pre => (pre + 1) % imageIds.length);
+    }
+  };
+
   return (
     <header className="box-border flex h-[116px] w-full items-center justify-between gap-12 border-b-[5px] border-solid border-b-[#0F62FE] px-[30px] py-[47px]">
       <h1 className="whitespace-nowrap text-left text-xl font-bold leading-[10px]">
@@ -91,10 +117,10 @@ const Header = ({ currentEl }: { currentEl: HTMLDivElement | undefined }) => {
           <button className="feat-btn">Apply Colormap</button>
           <button className="feat-btn">Reset</button>
         </div>
-        <button className="img-btn">
+        <button className="img-btn" onClick={previousHeandler}>
           <span className="px-2">Previous Image</span>
         </button>
-        <button className="img-btn">
+        <button className="img-btn" onClick={nextHandler}>
           <span className="px-2">Next Image</span>
         </button>
       </div>


### PR DESCRIPTION
close #11 

## Description

<!-- 작업 내용을 적어주세요. -->

### 1. feat: Previous & Next Image 기능 구현

- 두 currentEl 마다 서로 다른 Image Index 상태를 주어 기능을 구현하였습니다.
- 버튼을 누르면 Image Index 감소 혹은 증가 시켜 imageIds 리스트에 있는 이미지 id를 가져와 사용하였습니다.
- 새롭게 가져온 id를 활용하여 loadAndCacheImage와 displayImage를 통해  이미지를 다시 로드하였습니다.
- 이때 useEffect를 사용하여 index 상태가 변할 때 현재 요소에 대해서만 이미지가 다시 로드되도록 하였습니다.

## 스크린샷 (Optional)

https://github.com/JitHoon/dicom-viewer/assets/101972330/4b740aff-07d1-47ea-b813-66a0ad9549e4
