### PR TITLE
[#13] Apply Colormap 및 Reset 기능 구현

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -76,6 +76,24 @@ const Header = ({
     }
   };
 
+  const colormapHandler = () => {
+    if (currentEl) {
+      cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
+        mouseButtonMask: 1
+      });
+
+      const viewport = cornerstone.getViewport(currentEl);
+      const colormap = cornerstone.colors.getColormap('jet', { name: 'Jet' });
+
+      if (viewport) {
+        viewport.colormap = colormap;
+
+        cornerstone.setViewport(currentEl, viewport);
+        cornerstone.updateImage(currentEl, true);
+      }
+    }
+  };
+
   const resetHandler = () => {
     if (currentEl) {
       cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
@@ -123,7 +141,9 @@ const Header = ({
           <button className="feat-btn" onClick={invertHandler}>
             Invert
           </button>
-          <button className="feat-btn">Apply Colormap</button>
+          <button className="feat-btn" onClick={colormapHandler}>
+            Apply Colormap
+          </button>
           <button className="feat-btn" onClick={resetHandler}>
             Reset
           </button>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -19,11 +19,11 @@ const Header = ({
   };
 
   const flipHHandler = () => {
-    cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
-      mouseButtonMask: 1
-    });
-
     if (currentEl) {
+      cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
+        mouseButtonMask: 1
+      });
+
       const viewport = cornerstone.getViewport(currentEl);
 
       if (viewport) {
@@ -34,11 +34,11 @@ const Header = ({
   };
 
   const flipVHandler = () => {
-    cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
-      mouseButtonMask: 1
-    });
-
     if (currentEl) {
+      cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
+        mouseButtonMask: 1
+      });
+
       const viewport = cornerstone.getViewport(currentEl);
 
       if (viewport) {
@@ -49,10 +49,10 @@ const Header = ({
   };
 
   const rotateHandler = () => {
-    cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
-      mouseButtonMask: 1
-    });
     if (currentEl) {
+      cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
+        mouseButtonMask: 1
+      });
       const viewport = cornerstone.getViewport(currentEl);
 
       if (viewport) {
@@ -63,16 +63,25 @@ const Header = ({
   };
 
   const invertHandler = () => {
-    cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
-      mouseButtonMask: 1
-    });
     if (currentEl) {
+      cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
+        mouseButtonMask: 1
+      });
       const viewport = cornerstone.getViewport(currentEl);
 
       if (viewport) {
         viewport.invert = !viewport.invert;
         cornerstone.setViewport(currentEl, viewport);
       }
+    }
+  };
+
+  const resetHandler = () => {
+    if (currentEl) {
+      cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
+        mouseButtonMask: 1
+      });
+      cornerstone.reset(currentEl);
     }
   };
 
@@ -115,7 +124,9 @@ const Header = ({
             Invert
           </button>
           <button className="feat-btn">Apply Colormap</button>
-          <button className="feat-btn">Reset</button>
+          <button className="feat-btn" onClick={resetHandler}>
+            Reset
+          </button>
         </div>
         <button className="img-btn" onClick={previousHeandler}>
           <span className="px-2">Previous Image</span>


### PR DESCRIPTION
close #13 

## Description

<!-- 작업 내용을 적어주세요. -->

### 1. Reset 기능 구현

## 유의할 점 및 ETC (Optional)

- colormap 기능이 정상적으로 동작하지 않습니다.
- 아래는 시도한 코드입니다.

```tsx
const colormapHandler = () => {
    if (currentEl) {
      cornerstoneTools.setToolEnabledForElement(currentEl, 'ZoomMouseWheel', {
        mouseButtonMask: 1
      });

      const viewport = cornerstone.getViewport(currentEl);
      const colormap = cornerstone.colors.getColormap('jet', { name: 'Jet' });

      if (viewport) {
        viewport.colormap = colormap;

        cornerstone.setViewport(currentEl, viewport);
        cornerstone.updateImage(currentEl, true);
      }
    }
  };

// ...

<button className="feat-btn" onClick={colormapHandler}>Apply Colormap</button>
```

<!-- 팀원이 유의해야할 사항을 적어주세요. -->

## 스크린샷 (Optional)

https://github.com/JitHoon/dicom-viewer/assets/101972330/ed507d8a-7285-4f19-a37b-7110f7dda598
